### PR TITLE
Eigen repo has moved from bitbucket to gitlab

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,10 @@ def download_eigen():
     zippath = os.path.join('deps', 'eigen.zip')
     if not os.path.exists('deps'): os.mkdir('deps')
     if not os.path.exists(zippath):
-        req = urllib.request.Request("https://gitlab.com/libeigen/eigen/-/archive/3.3.4/eigen-3.3.4.zip", zippath, headers={"User-Agent": "Chrome"})
-        res = urllib.request.urlopen(req)
+        opener = urllib.request.build_opener()
+        opener.addheaders = [('User-agent', 'Chrome')]
+        urllib.request.install_opener(opener)
+        urllib.request.urlretrieve("https://gitlab.com/libeigen/eigen/-/archive/3.3.4/eigen-3.3.4.zip", zippath)
     
     f = zipfile.ZipFile(zippath)
     f.extractall('deps')

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def download_eigen():
     zippath = os.path.join('deps', 'eigen.zip')
     if not os.path.exists('deps'): os.mkdir('deps')
     if not os.path.exists(zippath):
-        req = urllib.request.Request("https://gitlab.com/libeigen/eigen/-/archive/3.3.4/eigen-3.3.4.zip", headers={"User-Agent": "Chrome"})
+        req = urllib.request.Request("https://gitlab.com/libeigen/eigen/-/archive/3.3.4/eigen-3.3.4.zip", zippath, headers={"User-Agent": "Chrome"})
         res = urllib.request.urlopen(req)
     
     f = zipfile.ZipFile(zippath)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def download_eigen():
     zippath = os.path.join('deps', 'eigen.zip')
     if not os.path.exists('deps'): os.mkdir('deps')
     if not os.path.exists(zippath):
-        urlretrieve("http://bitbucket.org/eigen/eigen/get/3.3.4.zip", zippath)
+        urlretrieve("https://gitlab.com/libeigen/eigen/-/archive/3.3.4/eigen-3.3.4.zip", zippath)
     
     f = zipfile.ZipFile(zippath)
     f.extractall('deps')

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools.command.build_ext import build_ext
 import sys
 import setuptools
 import os
+import urllib
 import subprocess
 from distutils.errors import CCompilerError, DistutilsExecError, \
     DistutilsPlatformError

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def download_eigen():
     
     f = zipfile.ZipFile(zippath)
     f.extractall('deps')
-    return os.path.join('deps', "eigen-eigen-5a0156e40feb")
+    return os.path.join('deps', "eigen-3.3.4")
     
 def get_eigen():
     if 'EIGEN3_INCLUDE_DIR' in os.environ:

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ def download_eigen():
     zippath = os.path.join('deps', 'eigen.zip')
     if not os.path.exists('deps'): os.mkdir('deps')
     if not os.path.exists(zippath):
-        urllib.URLopener.version = 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.153 Safari/537.36 SE 2.X MetaSr 1.0'
-        urlretrieve("https://gitlab.com/libeigen/eigen/-/archive/3.3.4/eigen-3.3.4.zip", zippath)
+        req = urllib.request.Request("https://gitlab.com/libeigen/eigen/-/archive/3.3.4/eigen-3.3.4.zip", headers={"User-Agent": "Chrome"})
+        res = urllib.request.urlopen(req)
     
     f = zipfile.ZipFile(zippath)
     f.extractall('deps')

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ def download_eigen():
     zippath = os.path.join('deps', 'eigen.zip')
     if not os.path.exists('deps'): os.mkdir('deps')
     if not os.path.exists(zippath):
+	urllib.URLopener.version = 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.153 Safari/537.36 SE 2.X MetaSr 1.0'
         urlretrieve("https://gitlab.com/libeigen/eigen/-/archive/3.3.4/eigen-3.3.4.zip", zippath)
     
     f = zipfile.ZipFile(zippath)

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def download_eigen():
     
 def get_eigen():
     if 'EIGEN3_INCLUDE_DIR' in os.environ:
-        return os.environ['EIGEN3_INCUDE_DIR']
+        return os.environ['EIGEN3_INCLUDE_DIR']
     return download_eigen()
     
 def download_pybind():
@@ -47,7 +47,7 @@ def download_pybind():
 
 def get_pybind():
     if 'PYBIND11_INCLUDE_DIR' in os.environ:
-        return os.environ['PYBIND11_INCUDE_DIR']
+        return os.environ['PYBIND11_INCLUDE_DIR']
     return download_pybind()
  
 # As of Python 3.6, CCompiler has a `has_flag` method.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools.command.build_ext import build_ext
 import sys
 import setuptools
 import os
-import urllib
+import urllib.request
 import subprocess
 from distutils.errors import CCompilerError, DistutilsExecError, \
     DistutilsPlatformError

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def download_eigen():
     zippath = os.path.join('deps', 'eigen.zip')
     if not os.path.exists('deps'): os.mkdir('deps')
     if not os.path.exists(zippath):
-	urllib.URLopener.version = 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.153 Safari/537.36 SE 2.X MetaSr 1.0'
+        urllib.URLopener.version = 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.153 Safari/537.36 SE 2.X MetaSr 1.0'
         urlretrieve("https://gitlab.com/libeigen/eigen/-/archive/3.3.4/eigen-3.3.4.zip", zippath)
     
     f = zipfile.ZipFile(zippath)


### PR DESCRIPTION
Change urlretrieve to the new gitlab eigen URL.

More info on the migration here - http://eigen.tuxfamily.org/index.php?title=News:Migration_to_GitLab.com_scheduled_on_the_December_4th